### PR TITLE
[FIX]: changing sleep with sleep_for which is portable

### DIFF
--- a/zia/main.cpp
+++ b/zia/main.cpp
@@ -1,12 +1,13 @@
 #include <iostream>
 #include "Log.hpp"
+#include <thread>
 
 int main()
 {
     std::cout << "I'm a program !" << std::endl;
     WARNLOG("I'm a warning bruh.");
-    Sleep(5000);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     INFOSLOG("I'm an infos 5 sec after the warning.");
-    Sleep(5000);
+    std::this_thread::sleep_for(std::chrono::seconds(5));
     ERRLOG("And I'm the final error 5 sec after the infos.");
 }


### PR DESCRIPTION
Sleep n'existe pas, il vaut mieux utilisé sleep_for qui est portable.
D'autant plus que sleep PEUT suspendre le processur dans linux, et suspend le thread dans windows.
Vu que de toute façon sleep est utilisé dans le main, suspendre le thread principale, revient à suspendre le processus, s'il n'y a qu'un thread